### PR TITLE
Removes underlined spaces between images

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,9 @@ src="https://github.com/blackcater/blackcater/raw/main/images/Hi.gif" height="32
 
 <br />
 
-<a href="https://www.blackcater.com" alt="blackcater's blog" target="_blank">
-  <img src="https://github.com/blackcater/blackcater/raw/main/images/social-blog.svg" height="40" />
-</a>
-<a href="mailto:i@blackcater.dev">
-  <img src="https://github.com/blackcater/blackcater/raw/main/images/social-gmail.svg" height="40" />
-</a>
-<a href="https://leetcode-cn.com/u/blackcater/">
-  <img src="https://github.com/blackcater/blackcater/raw/main/images/social-leetcode.svg" height="40" />
-</a>
+<a href="https://www.blackcater.com" alt="blackcater's blog" target="_blank"><img src="https://github.com/blackcater/blackcater/raw/main/images/social-blog.svg" height="40" /></a>
+<a href="mailto:i@blackcater.dev"><img src="https://github.com/blackcater/blackcater/raw/main/images/social-gmail.svg" height="40" /></a>
+<a href="https://leetcode-cn.com/u/blackcater/"><img src="https://github.com/blackcater/blackcater/raw/main/images/social-leetcode.svg" height="40" /></a>
 
 <br />
 <br />


### PR DESCRIPTION
Hey! Spotted your repo, I like the features.

The `README.md` images currently have an underlined space between them due to how HTML treats new lines inside links. Putting the `a` and `img` tags on one line is unfortunately the only way to fix it without CSS.

| Before | After |
| :-: | :-: |
| ![image](https://github.com/blackcater/blackcater/assets/12380876/9901e43f-8d32-4ae4-b9bd-7b78c192cfb0) | ![image](https://github.com/blackcater/blackcater/assets/12380876/ec557ca6-80b5-451a-ada7-ae27a2751920) |

If tidy code matters more to you than the visual output, feel free to ignore this PR 🙂 
